### PR TITLE
fix: release バンドルで i18n メッセージファイルが解決できない問題を修正

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -72,6 +72,10 @@ bwqa_version_ge() {
   return 0
 }
 
+# === i18n-load:begin ===
+# script/build.sh はバンドル生成時にこのブロックを、lib/i18n/*.sh の中身を
+# 埋め込んだ静的な case 文に置き換える(単一自己完結ファイルにするため)。
+# 開発時(lib/*.sh をリポジトリ内から直接 source する場合)はここでファイルから動的に読み込む。
 BWQA_LIB_DIR_INTERNAL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BWQA_LANG_RESOLVED="$(bwqa_detect_lang)"
 if [[ ! -f "$BWQA_LIB_DIR_INTERNAL/i18n/${BWQA_LANG_RESOLVED}.sh" ]]; then
@@ -79,3 +83,4 @@ if [[ ! -f "$BWQA_LIB_DIR_INTERNAL/i18n/${BWQA_LANG_RESOLVED}.sh" ]]; then
 fi
 # shellcheck disable=SC1090
 source "$BWQA_LIB_DIR_INTERNAL/i18n/${BWQA_LANG_RESOLVED}.sh"
+# === i18n-load:end ===

--- a/script/build.sh
+++ b/script/build.sh
@@ -27,6 +27,43 @@ LIBS=(
   "lib/fields.sh"
 )
 
+# lib/common.sh 内の i18n-load マーカー区間を、lib/i18n/*.sh の中身を埋め込んだ
+# 静的な case 文に置き換えて出力する。単一自己完結ファイルの前提上、
+# バンドル後に BASH_SOURCE 経由で外部の i18n/*.sh を実行時 source することはできないため。
+write_common_lib_inlined() {
+  local lib_path="$1"
+  local in_i18n_block=false
+  local line
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == *"=== i18n-load:begin ==="* ]]; then
+      in_i18n_block=true
+      echo 'BWQA_LANG_RESOLVED="$(bwqa_detect_lang)"' >> "$TMP_OUT"
+      echo 'case "$BWQA_LANG_RESOLVED" in' >> "$TMP_OUT"
+      local lang_file lang
+      for lang_file in "$REPO_ROOT"/lib/i18n/*.sh; do
+        lang="$(basename "$lang_file" .sh)"
+        echo "  $lang)" >> "$TMP_OUT"
+        cat "$lang_file" >> "$TMP_OUT"
+        echo "  ;;" >> "$TMP_OUT"
+      done
+      echo '  *)' >> "$TMP_OUT"
+      cat "$REPO_ROOT/lib/i18n/en.sh" >> "$TMP_OUT"
+      echo '  ;;' >> "$TMP_OUT"
+      echo 'esac' >> "$TMP_OUT"
+      continue
+    fi
+    if [[ "$line" == *"=== i18n-load:end ==="* ]]; then
+      in_i18n_block=false
+      continue
+    fi
+    if $in_i18n_block; then
+      continue
+    fi
+    echo "$line" >> "$TMP_OUT"
+  done < "$lib_path"
+}
+
 # ヘッダーと本体を動的に判別して連結する
 in_header=true
 in_source_block=false
@@ -81,7 +118,11 @@ while IFS= read -r line || [[ -n "$line" ]]; do
           exit 1
         fi
         echo "# === START $lib ===" >> "$TMP_OUT"
-        cat "$lib_path" >> "$TMP_OUT"
+        if [[ "$lib" == "lib/common.sh" ]]; then
+          write_common_lib_inlined "$lib_path"
+        else
+          cat "$lib_path" >> "$TMP_OUT"
+        fi
         echo "# === END $lib ===" >> "$TMP_OUT"
         echo "" >> "$TMP_OUT"
       done


### PR DESCRIPTION
## Summary
- v0.2.0 の Release Packaging workflow が Smoke test ステップで `dist/i18n/en.sh: No such file or directory` により失敗していた原因を修正
- `script/build.sh` は `lib/*.sh` を単一自己完結スクリプトへ連結するが、`lib/common.sh` は `BASH_SOURCE[0]` を基準に実行時に `lib/i18n/*.sh` を `source` する設計だった。バンドル後は `BASH_SOURCE[0]` が `dist/bw-quickaccess` 自身を指すため、存在しない `dist/i18n/*.sh` を探しに行き失敗していた
- `lib/common.sh` に i18n-load マーカーを追加し、`build.sh` がバンドル時にその区間を `lib/i18n/*.sh` の中身を埋め込んだ静的な `case` 文へ置換するようにした
- 開発時(`lib/*.sh` を直接 `source` する場合)は従来通り動的な `source` のままなので挙動は変わらない

## Test plan
- [x] ローカルで `script/build.sh` を実行し、生成された `dist/bw-quickaccess` に対して `--version` / `--help` (en/ja両方) / `bash -n` が成功することを確認済み
- [ ] CI (`ci.yml`): 構文チェック・shellcheck・bats テスト
- [ ] このPRマージ後、次回リリース時に Release Packaging workflow (`release.yml`) の Smoke test が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)