### PR TITLE
docs: fix release asset filename in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,8 +19,8 @@ Bitwarden向けの、1Password Quick Access 相当のメニューバー常駐ア
 
 ### 方法1: GitHub Releasesからダウンロード(推奨)
 
-1. [Releasesページ](https://github.com/kuchida1981/bitwarden-quickaccess/releases)から `bw-quickaccess.app.zip` をダウンロードする
-2. 展開して `bw-quickaccess.app` を `/Applications`(お好きな場所でも構いません)に移動する
+1. [Releasesページ](https://github.com/kuchida1981/bitwarden-quickaccess/releases)から `bw-quickaccess_aarch64.app.tar.gz` をダウンロードする。このビルドは **Apple Silicon(arm64)専用**です。Intel Macは現時点でビルド済みリリースの対象外です(方法2のセルフビルドを利用してください)
+2. 展開して(Finderでダブルクリック、または `tar -xzf bw-quickaccess_aarch64.app.tar.gz`)、`bw-quickaccess.app` を `/Applications`(お好きな場所でも構いません)に移動する
 3. このアプリは**コード署名・notarizationされていません**。初回起動時、macOSのGatekeeperが「開発元を確認できません」という警告を出して起動をブロックします。以下の手順で起動してください:
    - Finderで `bw-quickaccess.app` を右クリック(またはControl+クリック)し、**「開く」**を選択、表示されるダイアログでも**「開く」**を選ぶ
    - この操作は初回のみ必要です。以降は通常どおり起動できます

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To **self-build**, you additionally need:
 
 ### Option 1: Download from GitHub Releases (recommended)
 
-1. Download `bw-quickaccess.app.zip` from the [Releases page](https://github.com/kuchida1981/bitwarden-quickaccess/releases).
-2. Unzip it and move `bw-quickaccess.app` to `/Applications` (or anywhere you like).
+1. Download `bw-quickaccess_aarch64.app.tar.gz` from the [Releases page](https://github.com/kuchida1981/bitwarden-quickaccess/releases). This build targets **Apple Silicon (arm64) only**; Intel Macs are not currently supported by the prebuilt release (self-build from source instead — see Option 2).
+2. Extract it (double-click in Finder, or `tar -xzf bw-quickaccess_aarch64.app.tar.gz`) and move `bw-quickaccess.app` to `/Applications` (or anywhere you like).
 3. The app is **not code-signed or notarized**. On first launch, macOS Gatekeeper will refuse to open it with an "unidentified developer" warning. To open it anyway:
    - Right-click (or Control-click) `bw-quickaccess.app` in Finder and choose **Open**, then confirm **Open** in the dialog that appears.
    - You only need to do this once; subsequent launches work normally.


### PR DESCRIPTION
## Summary
v1.0.0 リリースを実際に作成して確認したところ、READMEに書いていた `bw-quickaccess.app.zip` は実際のアセット名(`bw-quickaccess_aarch64.app.tar.gz`)と異なっていたため修正しました。あわせて、現状のビルドは `macos-latest`(Apple Silicon)ランナー上でのみ行っておりIntel Mac向けバイナリは含まれない点も明記しました。

## Test plan
- [x] `gh release view v1.0.0` で実際のアセット名を確認し、READMEの記載と一致させた

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzUX64hzdzrUsVcz48DmtR