### PR TITLE
docs: CLAUDE.mdのCI記述を現行構成に修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,8 +220,8 @@ Bash ツールの `timeout` パラメータも併用し、agy プロセスが応
    → アーカイブと spec sync のコミットを PR に含める
 
 6. CI 確認 (Claude Code)
-   `.github/workflows/ci.yml` により push/PR ごとに CI(macos-latest / ubuntu-latest で
-   構文チェック・shellcheck・bats テスト)が実行される。
+   `.github/workflows/ci.yml` により push/PR ごとに CI(macos-latest 上で
+   `cargo build` / `cargo test` / `cargo clippy --all-targets -- -D warnings`)が実行される。
    PR 作成後は以下のコマンドで結果を待ち、失敗があれば修正してプッシュする:
    gh pr checks --watch
 ```
@@ -238,8 +238,9 @@ Bash ツールの `timeout` パラメータも併用し、agy プロセスが応
 ### pre-commit / CI ルール
 
 CI ワークフロー(`.github/workflows/ci.yml`)は設定済み。push/PR ごとに
-macos-latest / ubuntu-latest 上で構文チェック(`bash -n`)・`shellcheck`・
-`bats test/lib/*.bats` が実行される。pre-commit フックは現時点で未設定。
+macos-latest 上で `cargo build` / `cargo test` / `cargo clippy --all-targets -- -D warnings`
+が実行される(GUI書き換え以降、Linux向けジョブ・shellcheck・bats は対象外)。
+pre-commit フックは現時点で未設定。
 今後 pre-commit フックを追加した場合も以下を厳守する:
 
 **pre-commit のスキップ禁止**


### PR DESCRIPTION
## Summary
- CLAUDE.md の CI 説明が旧bash TUI時代のもの(macos-latest / ubuntu-latest でのshellcheck・batsテスト)のままだったため、GUI書き換え後の実際の構成(macos-latestのみ、cargo build/test/clippy)に合わせて修正

## Test plan
- ドキュメントのみの変更のため、既存のCIがそのまま通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzUX64hzdzrUsVcz48DmtR