### PR TITLE
fix: パッケージバージョンをリリースタグと同期する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      - name: Sync Cargo.toml version with the release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          sed -i '' "s/^version = \".*\"/version = \"$version\"/" app/src-tauri/Cargo.toml
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -356,7 +356,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bw-quickaccess-gui"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "libc",
  "objc2-app-kit",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bw-quickaccess-gui"
-version = "0.1.0"
+version = "1.0.0"
 description = "Menu-bar Quick Access GUI for Bitwarden (bw serve backend)"
 edition = "2021"
 


### PR DESCRIPTION
## Summary
- `Cargo.toml` の `version` が初期値 `0.1.0` のまま一度も更新されておらず、v0.1.0/v0.2.0/v1.0.0と3回リリースされているにもかかわらずズレていた問題を修正
- `release.yml` に、リリースタグから `Cargo.toml` のバージョンを自動同期するステップを追加(mainブランチへのコミットは発生させない。ブランチ保護でCIからの直接pushができないため、ビルド時にチェックアウト先の`Cargo.toml`を書き換えるだけの方式)

## 背景
`about-and-branding`(#57)でトレイメニューにバージョン表示を追加したが、`Cargo.toml`のバージョンが更新されないままだと、この表示が永久に古い値のまま固定されてしまうことに気づいた。

## Test plan
- [x] `cargo build` で `Cargo.toml` の変更が反映され、`Cargo.lock` も自動同期されることを確認
- [x] `release.yml` のYAML構文を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzUX64hzdzrUsVcz48DmtR