### PR TITLE
docs: リリース手順をCONTRIBUTING.mdに明記し、CLAUDE.mdから導線を引く

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,58 @@ gh pr checks --watch   # 成功: exit 0 / 失敗: exit 非0
 
 失敗した場合は `gh pr checks` でどのジョブが落ちたかを確認し、修正 → コミット → プッシュ → 再度 watch のサイクルで是正する。
 
+### リリース手順
+
+新しいバージョンをリリースするときの手順。以下の順序で実行する。
+
+**1. GitHub Releaseを作成する**
+
+`vX.Y.Z` 形式のタグ(セマンティックバージョニング)でGitHub Releaseを作成する。
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."
+```
+
+`Cargo.toml` の `version` を事前に手動で書き換える必要はない。`.github/workflows/release.yml` がビルド時にリリースタグから自動でバージョンを同期する(「Sync Cargo.toml version with the release tag」ステップ)。この同期はビルド用のチェックアウト内でのみ行われ、mainブランチへのコミットは発生しない(ブランチ保護によりCIから直接pushできないため)。
+
+リリースノートは過去のリリース(`gh release view v1.1.0 --json body` 等で参照可能)の構成に合わせる: 新機能・バグ修正・インストール方法・対象OSのセクションに分ける。
+
+**2. ビルド完了を待つ**
+
+Releaseの公開をトリガーに `.github/workflows/release.yml` が起動し、`.app` をビルドしてリリースアセット(`bw-quickaccess_aarch64.app.tar.gz`)をアップロードする。
+
+```bash
+gh run list --workflow=release.yml --limit 1
+gh run watch <run-id> --exit-status
+```
+
+**3. Homebrew tapのCaskを更新する**
+
+tapリポジトリ: https://github.com/kuchida1981/homebrew-bitwarden-quickaccess (別リポジトリ。ローカルにcloneして作業する)
+
+1. 新しいリリースのタグとアセットのsha256を取得する(ダウンロードして自分で計算する必要はない。`digest` フィールドに含まれている):
+   ```bash
+   gh release view vX.Y.Z --repo kuchida1981/bitwarden-quickaccess --json tagName,assets
+   ```
+2. tapリポジトリの `Casks/bw-quickaccess.rb` の `version` と `sha256` を、1で取得した値に更新する。
+3. ローカルで `brew tap kuchida1981/bitwarden-quickaccess` 済みであれば、変更をtap先のディレクトリ(`$(brew --repository)/Library/Taps/kuchida1981/homebrew-bitwarden-quickaccess/Casks/bw-quickaccess.rb`)にも反映してlintする:
+   ```bash
+   brew style --cask bw-quickaccess
+   brew audit --cask bw-quickaccess
+   ```
+4. `brew reinstall --cask bw-quickaccess` で実際にインストールし直し、起動・アンロックできることを実機確認する。
+5. tapリポジトリの変更をコミット・プッシュする(このリポジトリのブランチ保護は適用されないため直接pushしてよいが、内容は事前にユーザーと合意しておく)。
+
+tapリポジトリ側のCask更新手順自体は、tapリポジトリ自身のREADMEにも同じ内容を記載している。
+
+**4. マイルストーンをクローズする(該当する場合)**
+
+そのリリースが特定のGitHub Milestoneに対応する場合、完了後にクローズする:
+
+```bash
+gh api repos/kuchida1981/bitwarden-quickaccess/milestones/<番号> -X PATCH -f state=closed
+```
+
 ### OpenSpec チートシート
 
 | スキル | 用途 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,55 +258,13 @@ gh pr checks --watch   # 成功: exit 0 / 失敗: exit 非0
 
 ### リリース手順
 
-新しいバージョンをリリースするときの手順。以下の順序で実行する。
+**詳細な手順は [CONTRIBUTING.md](CONTRIBUTING.md#releasing) を参照すること。** リリース作業(GitHub Release作成、`release.yml` のビルド待ち、Homebrew tap `kuchida1981/homebrew-bitwarden-quickaccess` のCask更新、マイルストームクローズ)を行う際は、必ず先にCONTRIBUTING.mdを読んでから着手する。
 
-**1. GitHub Releaseを作成する**
-
-`vX.Y.Z` 形式のタグ(セマンティックバージョニング)でGitHub Releaseを作成する。
-
-```bash
-gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."
-```
-
-`Cargo.toml` の `version` を事前に手動で書き換える必要はない。`.github/workflows/release.yml` がビルド時にリリースタグから自動でバージョンを同期する(「Sync Cargo.toml version with the release tag」ステップ)。この同期はビルド用のチェックアウト内でのみ行われ、mainブランチへのコミットは発生しない(ブランチ保護によりCIから直接pushできないため)。
-
-リリースノートは過去のリリース(`gh release view v1.1.0 --json body` 等で参照可能)の構成に合わせる: 新機能・バグ修正・インストール方法・対象OSのセクションに分ける。
-
-**2. ビルド完了を待つ**
-
-Releaseの公開をトリガーに `.github/workflows/release.yml` が起動し、`.app` をビルドしてリリースアセット(`bw-quickaccess_aarch64.app.tar.gz`)をアップロードする。
-
-```bash
-gh run list --workflow=release.yml --limit 1
-gh run watch <run-id> --exit-status
-```
-
-**3. Homebrew tapのCaskを更新する**
-
-tapリポジトリ: https://github.com/kuchida1981/homebrew-bitwarden-quickaccess (別リポジトリ。ローカルにcloneして作業する)
-
-1. 新しいリリースのタグとアセットのsha256を取得する(ダウンロードして自分で計算する必要はない。`digest` フィールドに含まれている):
-   ```bash
-   gh release view vX.Y.Z --repo kuchida1981/bitwarden-quickaccess --json tagName,assets
-   ```
-2. tapリポジトリの `Casks/bw-quickaccess.rb` の `version` と `sha256` を、1で取得した値に更新する。
-3. ローカルで `brew tap kuchida1981/bitwarden-quickaccess` 済みであれば、変更をtap先のディレクトリ(`$(brew --repository)/Library/Taps/kuchida1981/homebrew-bitwarden-quickaccess/Casks/bw-quickaccess.rb`)にも反映してlintする:
-   ```bash
-   brew style --cask bw-quickaccess
-   brew audit --cask bw-quickaccess
-   ```
-4. `brew reinstall --cask bw-quickaccess` で実際にインストールし直し、起動・アンロックできることを実機確認する。
-5. tapリポジトリの変更をコミット・プッシュする(このリポジトリのブランチ保護は適用されないため直接pushしてよいが、内容は事前にユーザーと合意しておく)。
-
-tapリポジトリ側のCask更新手順自体は、tapリポジトリ自身のREADMEにも同じ内容を記載している。
-
-**4. マイルストーンをクローズする(該当する場合)**
-
-そのリリースが特定のGitHub Milestoneに対応する場合、完了後にクローズする:
-
-```bash
-gh api repos/kuchida1981/bitwarden-quickaccess/milestones/<番号> -X PATCH -f state=closed
-```
+概要のみ記す:
+1. `gh release create vX.Y.Z ...` でリリースを作成する(`Cargo.toml` の手動バージョン更新は不要。`release.yml` がタグから自動同期する)
+2. `release.yml` のビルド完了を待つ(`gh run watch`)
+3. 別リポジトリのHomebrew tapのCask(`version`/`sha256`)を更新し、`brew style`/`brew audit`/`brew reinstall --cask` で確認してからコミット・プッシュする
+4. 該当するマイルストーンがあればクローズする
 
 ### OpenSpec チートシート
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+開発環境のセットアップ・セルフビルド手順は [README.md](README.md#option-3-self-build-from-source) を参照してください。AIエージェント(Claude Code / Antigravity CLI)を使った開発ワークフロー(OpenSpecでの提案・実装フロー、ツールの役割分担)については [CLAUDE.md](CLAUDE.md) を参照してください。
+
+## Releasing
+
+新しいバージョンをリリースするときの手順。以下の順序で実行する。
+
+### 1. GitHub Releaseを作成する
+
+`vX.Y.Z` 形式のタグ(セマンティックバージョニング)でGitHub Releaseを作成する。
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."
+```
+
+`Cargo.toml` の `version` を事前に手動で書き換える必要はない。`.github/workflows/release.yml` がビルド時にリリースタグから自動でバージョンを同期する(「Sync Cargo.toml version with the release tag」ステップ)。この同期はビルド用のチェックアウト内でのみ行われ、mainブランチへのコミットは発生しない(ブランチ保護によりCIから直接pushできないため)。
+
+リリースノートは過去のリリース(`gh release view v1.1.0 --json body` 等で参照可能)の構成に合わせる: 新機能・バグ修正・インストール方法・対象OSのセクションに分ける。
+
+### 2. ビルド完了を待つ
+
+Releaseの公開をトリガーに `.github/workflows/release.yml` が起動し、`.app` をビルドしてリリースアセット(`bw-quickaccess_aarch64.app.tar.gz`)をアップロードする。
+
+```bash
+gh run list --workflow=release.yml --limit 1
+gh run watch <run-id> --exit-status
+```
+
+### 3. Homebrew tapのCaskを更新する
+
+tapリポジトリ: https://github.com/kuchida1981/homebrew-bitwarden-quickaccess (別リポジトリ。ローカルにcloneして作業する)
+
+1. 新しいリリースのタグとアセットのsha256を取得する(ダウンロードして自分で計算する必要はない。`digest` フィールドに含まれている):
+   ```bash
+   gh release view vX.Y.Z --repo kuchida1981/bitwarden-quickaccess --json tagName,assets
+   ```
+2. tapリポジトリの `Casks/bw-quickaccess.rb` の `version` と `sha256` を、1で取得した値に更新する。
+3. ローカルで `brew tap kuchida1981/bitwarden-quickaccess` 済みであれば、変更をtap先のディレクトリ(`$(brew --repository)/Library/Taps/kuchida1981/homebrew-bitwarden-quickaccess/Casks/bw-quickaccess.rb`)にも反映してlintする:
+   ```bash
+   brew style --cask bw-quickaccess
+   brew audit --cask bw-quickaccess
+   ```
+4. `brew reinstall --cask bw-quickaccess` で実際にインストールし直し、起動・アンロックできることを実機確認する。
+5. tapリポジトリの変更をコミット・プッシュする。
+
+tapリポジトリ自身のREADMEにも同じ手順を記載している。
+
+### 4. マイルストーンをクローズする(該当する場合)
+
+そのリリースが特定のGitHub Milestoneに対応する場合、完了後にクローズする:
+
+```bash
+gh api repos/kuchida1981/bitwarden-quickaccess/milestones/<番号> -X PATCH -f state=closed
+```


### PR DESCRIPTION
## Summary
リリース時に手動で必要な手順(GitHub Release作成→ビルド待ち→Homebrew tapのCask更新→マイルストーンクローズ)が、これまでどこにもドキュメント化されていなかったため追記した。

当初CLAUDE.mdに直接書いたが、リリース手順はAIエージェント固有の話ではなく人間の開発者にも必要な情報のため、開発者向けドキュメントとして新設した `CONTRIBUTING.md` に実体を置き、`CLAUDE.md` からは要点+リンクで導線を引く構成に変更した。

## Test plan
ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzUX64hzdzrUsVcz48DmtR