### PR TITLE
brew bump-cask-prがuntrusted tapで失敗する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,14 @@ jobs:
       # tapのcask定義を読み込む前に明示的な信頼付けを要求する(「Refusing to load
       # cask ... from untrusted tap ...」)。これを行わないと `brew bump-cask-pr`
       # (既存caskを読み込んでバージョンを比較する)も、後段の `brew install --cask`
-      # も同じ理由で失敗する。
+      # も同じ理由で失敗する。バレ形式(`brew trust <tap>`)を使う。実際のCIの
+      # エラーメッセージ自身がこの構文を提示しており、ローカルでもuntrust→trust
+      # のサイクルで動作を実機確認済み(`--tap`フラグは手元のHomebrewの
+      # `--help`には存在するが、外部ドキュメントと食い違いがあったため、より
+      # 確実なバレ形式を採用した)。
       - name: Trust the Homebrew tap
         continue-on-error: true
-        run: brew trust --tap kuchida1981/bitwarden-quickaccess
+        run: brew trust kuchida1981/bitwarden-quickaccess
 
       - name: Open a Homebrew tap update PR
         id: bump_cask_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,15 @@ jobs:
         continue-on-error: true
         run: brew tap kuchida1981/bitwarden-quickaccess
 
+      # 実リリースでの実地検証(タスク3.4)で発覚: 最近のHomebrewは、サードパーティ
+      # tapのcask定義を読み込む前に明示的な信頼付けを要求する(「Refusing to load
+      # cask ... from untrusted tap ...」)。これを行わないと `brew bump-cask-pr`
+      # (既存caskを読み込んでバージョンを比較する)も、後段の `brew install --cask`
+      # も同じ理由で失敗する。
+      - name: Trust the Homebrew tap
+        continue-on-error: true
+        run: brew trust --tap kuchida1981/bitwarden-quickaccess
+
       - name: Open a Homebrew tap update PR
         id: bump_cask_pr
         continue-on-error: true


### PR DESCRIPTION
## Summary
- v1.2.0の実リリースで発覚: 最近のHomebrewはサードパーティtapのcask定義読み込み前に明示的な信頼付け(`brew trust`)を要求するため、`brew bump-cask-pr`が「Refusing to load cask ... from untrusted tap ...」で失敗し、tap更新PRが作成されなかった
- `Tap the Homebrew repository` の直後に `brew trust kuchida1981/bitwarden-quickaccess` ステップを追加
- コードレビューで`--tap`フラグの妥当性について外部ドキュメントとの食い違いが指摘されたため、実際のCIエラーメッセージが提示していたバレ形式(`brew trust <tap>`)に修正し、ローカルでuntrust→trustのフルサイクルを実機検証済み

このステップも`continue-on-error: true`のため、ジョブ全体は既に成功していた(失敗は非表示のアノテーションとしてのみ表面化していた)。

Fixes #100

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` および `actionlint` でワークフローYAMLを検証(警告なし)
- [x] ローカルで実際のtap(`kuchida1981/bitwarden-quickaccess`)に対し `brew untrust` → `brew trust`(バレ形式)のフルサイクルを実行し、成功することを確認
- [x] コードレビュー2回(1回目で`--tap`構文への懸念、2回目でクリーン)
- [ ] 次回の実リリースで、tap更新PRが実際に作成されることを確認(本PRのスコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yFJLmAwxYyES27thwmiZQ