### PR TITLE
brew installの無効なフラグ--no-quarantineを削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,4 +119,8 @@ jobs:
             git -C "$tap_dir" fetch origin "$branch"
             git -C "$tap_dir" checkout -B "$branch" "origin/$branch"
           }
-          brew install --cask --no-quarantine bw-quickaccess
+          # v1.2.1の実リリースで発覚: `--no-quarantine` はこのHomebrewバージョンには
+          # 存在しないフラグ(`brew install --help`に見当たらない)。このステップの
+          # 目的はインストールが完了することの確認のみ(GUI起動確認は対象外)であり、
+          # Gatekeeper回避自体はここでは不要なため、フラグを外すだけで良い。
+          brew install --cask bw-quickaccess


### PR DESCRIPTION
## Summary
- v1.2.1の実リリースで発覚: `--no-quarantine` フラグが現行のHomebrewバージョンには存在しない(`invalid option: --no-quarantine`)
- 「Verify the cask installs (non-blocking)」ステップの目的(インストール完了の確認のみ)にはこのフラグ自体が不要なため削除

`continue-on-error: true`のため、このエラーが起きてもリリースジョブ全体・tap更新PR自体は正常だった。

Fixes #102

(別件: tapリポジトリのcaveatsが同じ無効フラグを案内している問題は kuchida1981/homebrew-bitwarden-quickaccess#2 で別途追跡)

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` および `actionlint` でワークフローYAMLを検証(警告なし)
- [x] コードレビュー実施、クリーン
- [ ] 次回の実リリースで、このステップがエラー無く完了することを確認(本PRのスコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yFJLmAwxYyES27thwmiZQ