### PR TITLE
docs: Homebrew Cask手動修正手順を具体化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,17 @@ gh run watch <run-id> --exit-status
 2. 内容(`version`/`sha256`が正しいか)を確認し、問題なければマージする。
 3. リリースジョブのログで「Verify the cask installs」ステップが失敗している場合は、内容を確認した上で手動で `brew reinstall --cask bw-quickaccess` を実行し、起動・アンロックできることを実機確認する。
 
-**`productName`(`app/src-tauri/tauri.conf.json`)を変更したリリースでは、上記の自動PRをマージするだけでは不十分**: `brew bump-cask-pr` は `version`/`sha256` のみを更新し、Cask定義内のファイル名参照(`app` 行・`url` 行・`caveats` 文中の `.app` 名)は追従しない。そのリリースに限り、自動PRのマージ前後いずれかのタイミングで、tapリポジトリの `Casks/bw-quickaccess.rb` を以下のように手動編集する:
+**`productName`(`app/src-tauri/tauri.conf.json`)を変更したリリースでは、上記の自動PRをマージするだけでは不十分**: `brew bump-cask-pr` は `version`/`sha256` のみを更新し、Cask定義内のファイル名参照(`app` 行・`url` 行・`caveats` 文中の `.app` 名)は追従しない。そのリリースに限り、**自動作成されたPRのブランチに直接追加コミットする形で**手動修正する(自動PRをマージしてから別途直すと、修正が入るまでの間 `brew install --cask` が壊れたURLを指す状態になるため、マージ前に直すこと):
 
-1. `app "bw-quickaccess.app"` を新しい `productName` に基づくファイル名(例: `app "Bitwarden Quick Access.app"`)に書き換える。
+```bash
+gh pr checkout <PR番号> --repo kuchida1981/homebrew-bitwarden-quickaccess
+```
+
+1. `Casks/bw-quickaccess.rb` の `app "bw-quickaccess.app"` を新しい `productName` に基づくファイル名(例: `app "Bitwarden Quick Access.app"`)に書き換える。
 2. `caveats` 文中の `.app` 名の記載も同様に書き換える。
 3. `url` 行のファイル名にスペースが含まれる場合、生のスペースのままだとダウンロードURLとして不正になるため、`%20` にパーセントエンコードする(例: `.../Bitwarden%20Quick%20Access_aarch64.app.tar.gz`)。Cask名(token、`bw-quickaccess`)や `name` 行は変更しない。
 4. `brew style --cask bw-quickaccess` / `brew audit --cask bw-quickaccess` / `brew reinstall --cask bw-quickaccess` で確認する(下記トラブルシューティング手順の3〜4と同じ)。
+5. 変更をコミット・プッシュして(`git push`)、自動PRのブランチを更新した上で、通常通りそのPRをマージする。
 
 `productName` を変更しない通常のリリースでは、この追加手順は不要。
 


### PR DESCRIPTION
## Summary
- PR #115(Finder上のアプリ名変更)で追記した、Homebrew tapのCask定義(`app`/`url`/`caveats`)の手動修正手順が抽象的だったため、`gh pr checkout` で自動作成PRのブランチに直接追加コミットする具体的な手順に明確化した
- 自動PRを先にマージしてから別途直すと、修正が入るまでの間 `brew install --cask` が壊れたURLを指す状態になってしまうため、マージ前に直すべきという注意点も明記した

## Test plan
- ドキュメントのみの変更のため、`cargo test`/`cargo clippy` への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yFJLmAwxYyES27thwmiZQ